### PR TITLE
Fix for recursive version of rmdir

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -214,10 +214,15 @@ SftpClient.prototype.rmdir = function(path, recursive) {
                             });
                         }
                     } else {
-                        return sftp.rmdir(p, (err) => {
-                            if (err) {
-                                reject(err);
-                            }
+                        return new Promise((resolve, reject) => {
+                            return sftp.rmdir(p, (err) => {
+                                if (err) {
+                                    reject(err);
+                                }
+                                else {
+                                    resolve();
+                                }
+                            });
                         });
                     }
                 });


### PR DESCRIPTION
The current implementation does not use properly the Promises for the 'SftpClient.rmdir' method if the flag 'recursive' is set to 'true', as a result the 'sftp.rmdir' is called after the outer Promise is resolved.
With this fix the outer Promise will be either resolved or rejected only after the 'sftp.rmdir' is finished.